### PR TITLE
fix: add buildx to docker build command

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,10 +30,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
       -
-        # Add support for more platforms with QEMU (optional)
-        # https://github.com/docker/setup-qemu-action
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
       - name: Build auto-instrumentation
         run: |
           make docker-build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,11 +29,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          platforms: linux/amd64,linux/arm64
       - name: Build auto-instrumentation
         run: |
           make docker-build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,6 +29,11 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      -
+        # Add support for more platforms with QEMU (optional)
+        # https://github.com/docker/setup-qemu-action
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Build auto-instrumentation
         run: |
           make docker-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM fedora:38 as builder
-ARG TARGETARCH
-RUN echo "arch: $TARGETARCH"
+ARG BUILDARCH
+RUN echo "arch: $BUILDARCH"
 RUN dnf install clang llvm make libbpf-devel -y
-RUN curl -LO https://go.dev/dl/go1.20.linux-${TARGETARCH}.tar.gz && tar -C /usr/local -xzf go*.linux-$TARGETARCH.tar.gz
+RUN curl -LO https://go.dev/dl/go1.20.linux-${BUILDARCH}.tar.gz && tar -C /usr/local -xzf go*.linux-${BUILDARCH}.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"
 WORKDIR /app
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM fedora:38 as builder
-ARG BUILDARCH
-RUN echo "arch: $BUILDARCH"
+ARG TARGETARCH
+RUN echo "arch: $TARGETARCH"
 RUN dnf install clang llvm make libbpf-devel -y
-RUN curl -LO https://go.dev/dl/go1.20.linux-${BUILDARCH}.tar.gz && tar -C /usr/local -xzf go*.linux-${BUILDARCH}.tar.gz
+RUN curl -LO https://go.dev/dl/go1.20.linux-${TARGETARCH}}.tar.gz && tar -C /usr/local -xzf go*.linux-${TARGETARCH}.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"
 WORKDIR /app
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:38 as builder
 ARG TARGETARCH
 RUN echo "arch: $TARGETARCH"
 RUN dnf install clang llvm make libbpf-devel -y
-RUN curl -LO https://go.dev/dl/go1.20.linux-${TARGETARCH}}.tar.gz && tar -C /usr/local -xzf go*.linux-${TARGETARCH}.tar.gz
+RUN curl -LO https://go.dev/dl/go1.20.linux-${TARGETARCH}.tar.gz && tar -C /usr/local -xzf go*.linux-${TARGETARCH}.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"
 WORKDIR /app
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:38 as builder
 ARG TARGETARCH
 RUN echo "arch: $TARGETARCH"
 RUN dnf install clang llvm make libbpf-devel -y
-RUN curl -LO https://go.dev/dl/go1.20.linux-$TARGETARCH.tar.gz && tar -C /usr/local -xzf go*.linux-$TARGETARCH.tar.gz
+RUN curl -LO https://go.dev/dl/go1.20.linux-${TARGETARCH}.tar.gz && tar -C /usr/local -xzf go*.linux-$TARGETARCH.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"
 WORKDIR /app
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build: generate
 
 .PHONY: docker-build
 docker-build:
-	docker buildx build --no-cache -t $(IMG) .
+	docker buildx build -t $(IMG) .
 
 .PHONY: offsets
 offsets:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build: generate
 
 .PHONY: docker-build
 docker-build:
-	docker build -t $(IMG) .
+	docker build --no-cache -t $(IMG) .
 
 .PHONY: offsets
 offsets:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build: generate
 
 .PHONY: docker-build
 docker-build:
-	docker build --no-cache -t $(IMG) .
+	docker buildx build --no-cache -t $(IMG) .
 
 .PHONY: offsets
 offsets:


### PR DESCRIPTION
## Which problem is this PR solving?
It looks like by default on Mac / Windows, when you run `docker build` it uses `buildx`. That isn't the case on linux, which is what we're running in CI so we have to explicitly build with `buildx` to get support for the `TARGETARCH` variable.

## Short description of the changes
- Updated Makefile to build with `buildx`

## How to verify that this has the expected result
- [x] Build step should pass CI
- [ ] E2E step should pass CI
- [x] Should be able to successfully run `make docker-build` locally
